### PR TITLE
Fix undesirable molecule length randomness in generate_molecules.py

### DIFF
--- a/simulating/generate_molecules.py
+++ b/simulating/generate_molecules.py
@@ -97,7 +97,7 @@ def generate_molecules_from_bed(genome_file_path,
             chr,pos = get_chr_pos_from_abs_postion(position=random.randint(1,genome_length), lengths=chrom_lengths)
             gene = 'no_gene'
         start = pos - math.floor(random.normalvariate(mu=mol_len/2, sigma=15))
-        end   = pos + mol_len
+        end   = start + mol_len
         if start <= 0 or end > len(genome[chr]):
             continue
         molecules.append((chr, gene, start, end))


### PR DESCRIPTION
I needed to generate molecules of a very specific length for a test, and I realised that even setting `molecule_size_dev=0` I obtained molecules of variable lengths :

`barL_6.barNum_4096/noPanel/ref_ROCHE-PETE.molMin_25.molMu_25.molDev_0.molNum3/barcoded_molecules.fa`

```
>0:FGFR1|ENST00000326324.10:no_gene:1396:1433:ATGCAA:AATATA
ATGCAAGTTAATACCACCGACAAAGAGATGGAGGTGCTTCACTAATATA
>1:NTRK2|ENST00000688333.1:no_gene:4281:4314:GATATC:CTTCCG
GATATCTCACCTCTATGGCCTCTGCGTTTTAGTGGGGTGCTTCCG
>2:VCP|ENST00000679800.1:no_gene:1695:1724:CTAGCA:CACTCT
CTAGCAGAGGATGAGACCATTGATGCCGAGGTCATCACTCT
```

This seems to originate from the starting position randomizer for BED entries, `start` is randomized from `pos` but `end` is also defined from `pos`, so `mol_len` is not enforced.

Great piece of software anyway !